### PR TITLE
Fix bug in which we double-escaped code blocks

### DIFF
--- a/nightbot.html
+++ b/nightbot.html
@@ -57,7 +57,7 @@ title: Gem's other website!
               {% assign formatted_vars = formatted_vars | push: formatted_var %}
             {% endfor %}
             <p>variables: {{ formatted_vars | join: ", "}}</p>
-            {% highlight js %}{{ pg | xml_escape }}{% endhighlight %}
+            {% highlight js %}{{ pg }}{% endhighlight %}
           </div>
         </li>
       {% endfor %}


### PR DESCRIPTION
If you look at nightbot.html, you'll see that I accidentally double-escaped the JS code. This means that currently, instead of `"` it'll say `&quot;` and similar for any special characters. This is the fix.