### PR TITLE
Don't break the build on invalid JS

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -48,6 +48,7 @@ jobs:
         run: for f in nb/{eyes,fish_0,fish_1,fish_off,gaboemote,gaussian,gordonramsay,LMS,test,typo_0}; do cp $f.js $f.json; done
       - name: Minify javascript
         working-directory: ${{ env.build_dir }}
+        continue-on-error: true
         run: npm run minify
         env:
           MIN_JS_DIR: ${{ env.output_dir }}/nb/


### PR DESCRIPTION
I don't know if you actually want this or not, but the build breaking like it did in f788c6bbbb8e60159a863026c4a8e21b9cc2a761 is not what I totally intended so this update will make invalid JS not break the build anymore, instead it will simply not produce minified versions of broken files.

If you're OK with invalid JS breaking the build, you're welcome to close this PR, I just wanted to give you the option to change this behavior.